### PR TITLE
feat: debounce writeState rather than removing the document right away

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+jobs:
+  test_and_release:
+    docker:
+      - image:  cimg/node:16.13
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm test
+      - run: npm run dist
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >> ]
+          steps:
+            - run: npm publish
+
+workflows:
+  test_and_release:
+    jobs:
+      - test_and_release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -307,6 +307,7 @@ const pingTimeout = 30000
  */
 exports.setupWSConnection = async (conn, req, { docName = req.url.slice(1).split('?')[0], gc = true } = {}) => {
   conn.binaryType = 'arraybuffer'
+  cancelClosing(docName)
   // get doc, initialize if it does not exist yet
   const doc = getYDoc(docName, gc, conn)
   doc.conns.set(conn, new Set())

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -272,7 +272,7 @@ const closeConn = (doc, conn) => {
 /**
  * @param {string} docName
  */
-export const cancelClosing = (docName) => {
+const cancelClosing = (docName) => {
   const timeout = closingTimeouts.get(docName)
   if (timeout) {
     clearTimeout(timeout)

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -88,7 +88,7 @@ const messageAwareness = 1
  * @type {Map<string, number>}
  */
 const closingTimeouts = new Map()
-exports.closingTimeouts = this.closingTimeouts
+exports.closingTimeouts = closingTimeouts
 
 /**
  * @param {Uint8Array} update

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -18,6 +18,14 @@ const readSyncMessage = require('./readSyncMessageFork.js').readSyncMessage
 
 const CALLBACK_DEBOUNCE_WAIT = parseInt(process.env.CALLBACK_DEBOUNCE_WAIT) || 2000
 const CALLBACK_DEBOUNCE_MAXWAIT = parseInt(process.env.CALLBACK_DEBOUNCE_MAXWAIT) || 10000
+let WRITE_STATE_DEBOUNCE_WAIT = 0
+
+/**
+ * @param {number} wait
+ */
+exports.setWriteStateDebounceWait = wait => {
+  WRITE_STATE_DEBOUNCE_WAIT = wait
+}
 
 const wsReadyStateConnecting = 0
 const wsReadyStateOpen = 1
@@ -228,11 +236,17 @@ const closeConn = (doc, conn) => {
     doc.conns.delete(conn)
     awarenessProtocol.removeAwarenessStates(doc.awareness, Array.from(controlledIds), null)
     if (doc.conns.size === 0 && persistence !== null) {
-      // if persisted, we store state and destroy ydocument
-      persistence.writeState(doc.name, doc).then(() => {
-        doc.destroy()
-      })
-      docs.delete(doc.name)
+      setTimeout(() => {
+        if (doc.conns.size === 0) {
+          // if persisted, we store state and destroy ydocument
+          persistence.writeState(doc.name, doc).then(async () => {
+            if (doc.conns.size === 0) {
+              docs.delete(doc.name)
+              doc.destroy()
+            }
+          })
+        }
+      }, WRITE_STATE_DEBOUNCE_WAIT)
     }
   }
   conn.close()

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -85,6 +85,12 @@ const messageAwareness = 1
 // const messageAuth = 2
 
 /**
+ * @type {Map<string, number>}
+ */
+const closingTimeouts = new Map()
+exports.closingTimeouts = this.closingTimeouts
+
+/**
  * @param {Uint8Array} update
  * @param {any} origin
  * @param {WSSharedDoc} doc
@@ -236,20 +242,42 @@ const closeConn = (doc, conn) => {
     doc.conns.delete(conn)
     awarenessProtocol.removeAwarenessStates(doc.awareness, Array.from(controlledIds), null)
     if (doc.conns.size === 0 && persistence !== null) {
-      setTimeout(() => {
-        if (doc.conns.size === 0) {
-          // if persisted, we store state and destroy ydocument
-          persistence.writeState(doc.name, doc).then(async () => {
+      cancelClosing(doc.name)
+      closingTimeouts.set(
+        doc.name,
+        setTimeout(
+          () => {
+            closingTimeouts.delete(doc.name)
             if (doc.conns.size === 0) {
-              docs.delete(doc.name)
-              doc.destroy()
+              // if persisted, we store state and destroy ydocument
+              persistence.writeState(doc.name, doc)
+                .then(
+                  async () => {
+                    if (doc.conns.size === 0) {
+                      docs.delete(doc.name)
+                      doc.destroy()
+                    }
+                  }
+                )
             }
-          })
-        }
-      }, WRITE_STATE_DEBOUNCE_WAIT)
+          },
+          WRITE_STATE_DEBOUNCE_WAIT
+        )
+      )
     }
   }
   conn.close()
+}
+
+/**
+ * @param {string} docName
+ */
+export const cancelClosing = (docName) => {
+  const timeout = closingTimeouts.get(docName)
+  if (timeout) {
+    clearTimeout(timeout)
+    closingTimeouts.delete(docName)
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "y-websocket",
-  "version": "1.4.0",
+  "name": "@stoplight/y-websocket",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "y-websocket",
-      "version": "1.4.0",
+      "name": "@stoplight/y-websocket",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/y-websocket",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Websockets provider for Yjs",
   "main": "./dist/y-websocket.cjs",
   "module": "./src/y-websocket.js",


### PR DESCRIPTION
## Motivation and Context
https://github.com/stoplightio/platform-internal/issues/11047

## Description
<!-- Describe your technical changes in detail. -->
This adds a debounce setting that defaults to 0ms and can be externally controlled by importing the `setWriteStateDebounceWait` like so:

```tsx
import { setWriteStateDebounceWait } from '@stoplight/y-websocket/bin/utils';
// 60 second debounce
setWriteStateDebounceWait(60000);
```

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
https://github.com/stoplightio/platform-internal/pull/11080
